### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": "^14 || ^16 || ^18"
+    "node": ">=14"
   },
   "scripts": {
     "build": "esbuild src/jwt.ts --bundle --outdir=dist --platform=node --external:jsonwebtoken --external:jwks-rsa",


### PR DESCRIPTION
Update Node engine to be >=14 to support additional & newer Node versions. This should fix a warning about using an unsupported engine in projects using Node 20:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'token-verify@0.1.6',
npm WARN EBADENGINE   required: { node: '^14 || ^16 || ^18' },
npm WARN EBADENGINE   current: { node: 'v20.10.0', npm: '10.2.3' }
npm WARN EBADENGINE }
```